### PR TITLE
docs: fix typo in example

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -50,7 +50,7 @@ func main() {
 
 	// Example ping request.
 	r.GET("/ping", func(c *gin.Context) {
-		c.String(, "pong "+fmt.Sprint(time.Now().Unix()))
+		c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
 	})
 
 	// Example skip path request.


### PR DESCRIPTION
64a5142 accidentally introduced a typo / copy-paste error so the example no longer compiles