### PR TITLE
feat: make log levels customizable

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ func main() {
     c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
   })
 
+  // Example custom log level.
+  r.GET("/debugonly", logger.SetLogger(
+    logger.WithDefaultLevel(zerolog.DebugLevel),
+  ), func(c *gin.Context) {
+    c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
+  })
+
   r.GET("/id", requestid.New(requestid.Config{
     Generator: func() string {
       return "foo-bar"


### PR DESCRIPTION
This PR introduces the possibility to customize the log level used when logging the requests.
Actually three differente log levels are used in three different cases

 - client errors (http status between 400 and 409) are logged as WARN
 - server errorr (http status >= 500) are logged as ERROR
 - all the other requests are logged as INFO

Using the options
- `WithClientErrorLevel`
- `WithServerErrorLevel`
- `WithDefaultLevel`

is now possible to change the default behaviour