### PR TITLE
Bugs/isatty hot path

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -32,6 +32,8 @@ type config struct {
 	serverErrorLevel zerolog.Level
 }
 
+var isTerm bool = isatty.IsTerminal(os.Stdout.Fd())
+
 // SetLogger initializes the logging middleware.
 func SetLogger(opts ...Option) gin.HandlerFunc {
 	cfg := &config{
@@ -56,7 +58,6 @@ func SetLogger(opts ...Option) gin.HandlerFunc {
 	}
 
 	return func(c *gin.Context) {
-		isTerm := isatty.IsTerminal(os.Stdout.Fd())
 		l := zerolog.New(cfg.output).
 			Output(
 				zerolog.ConsoleWriter{

--- a/logger_test.go
+++ b/logger_test.go
@@ -182,3 +182,24 @@ func TestLoggerParseLevel(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkLogger(b *testing.B) {
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.Use(SetLogger(WithDefaultLevel(zerolog.Disabled)))
+	r.GET("/", func(ctx *gin.Context) {
+		ctx.Data(200, "text/plain", []byte("all good"))
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	b.RunParallel(func(pb *testing.PB) {
+		req, _ := http.NewRequest("GET", "/", nil)
+		w := httptest.NewRecorder()
+
+		for pb.Next() {
+			r.ServeHTTP(w, req)
+		}
+	})
+}


### PR DESCRIPTION
Removing isatty call from the hot path significantly improve performance when using gin and zerolog via gin-contrig/logger.