### PR TITLE
chore(logger): update logger from context after middleware execution

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -99,6 +99,7 @@ func SetLogger(opts ...Option) gin.HandlerFunc {
 			}
 			latency := end.Sub(start)
 
+			l = *zerolog.Ctx(c.Request.Context())
 			l = l.With().
 				Int("status", c.Writer.Status()).
 				Str("method", c.Request.Method).


### PR DESCRIPTION
After middleware execution, the logger should be updated to reflect any changes to the context having been made in the middlewares. For example, if I have a tracing middleware that executes the following code, these attributes do not end up in the log:
```go
l := zerolog.Ctx(c.Request.Context())
l.UpdateContext(func(c zerolog.Context) zerolog.Context {
	return c.Str("trace_id", span.SpanContext().TraceID().String()).
		Str("span_id", span.SpanContext().SpanID().String())
})
```
To make it work, we need to update the context after middlewares have executed.
