### PR TITLE
Issue 58

### DIFF
--- a/options.go
+++ b/options.go
@@ -94,3 +94,17 @@ func WithMaxResponseBodyLen(maxResponseBodyLen int) Option {
 		}
 	})
 }
+
+func WithLogRequestBody(logRequestBody bool) Option {
+	return optionFunc(func(c *config) {
+		c.logRequestBody = logRequestBody
+	})
+}
+
+func WithMaxRequestBodyLen(maxRequestBodyLen int) Option {
+	return optionFunc(func(c *config) {
+		if maxRequestBodyLen > 0 {
+			c.maxRequestBodyLen = maxRequestBodyLen
+		}
+	})
+}

--- a/options.go
+++ b/options.go
@@ -74,3 +74,23 @@ func WithServerErrorLevel(lvl zerolog.Level) Option {
 		c.serverErrorLevel = lvl
 	})
 }
+
+func WithLogErrorResponseBody(logErrorResponseBody bool) Option {
+	return optionFunc(func(c *config) {
+		c.logErrorResponseBody = logErrorResponseBody
+	})
+}
+
+func WithLogResponseBody(logResponseBody bool) Option {
+	return optionFunc(func(c *config) {
+		c.logResponseBody = logResponseBody
+	})
+}
+
+func WithMaxResponseBodyLen(maxResponseBodyLen int) Option {
+	return optionFunc(func(c *config) {
+		if maxResponseBodyLen > 0 {
+			c.maxResponseBodyLen = maxResponseBodyLen
+		}
+	})
+}


### PR DESCRIPTION
Closes #58 

Added options to configure the log of request body, response body (for error/successful cases) and the maximum len allowed before truncating with `...`

Added test functions as well