### PR TITLE
Minor per-request allocation reduction

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -57,18 +57,17 @@ func SetLogger(opts ...Option) gin.HandlerFunc {
 		}
 	}
 
+	l := zerolog.New(cfg.output).
+		Output(
+			zerolog.ConsoleWriter{
+				Out:     cfg.output,
+				NoColor: !isTerm,
+			},
+		).
+		With().
+		Timestamp().
+		Logger()
 	return func(c *gin.Context) {
-		l := zerolog.New(cfg.output).
-			Output(
-				zerolog.ConsoleWriter{
-					Out:     cfg.output,
-					NoColor: !isTerm,
-				},
-			).
-			With().
-			Timestamp().
-			Logger()
-
 		if cfg.logger != nil {
 			l = cfg.logger(c, l)
 		}


### PR DESCRIPTION
In the middleware handler: the very first init of `l zerolog.Logger` does not yet depend on the request's `c *gin.Context`. It need not be allocated at the start of every request, since all later `l` usage happens anyway only after a new instance is allocated by `l.With`. With this change, it's inited-and-kept once per `gin.Engine`.