### PR TITLE
feat(option): add WithPathLevel option

### DIFF
--- a/options.go
+++ b/options.go
@@ -53,6 +53,13 @@ func WithSkipPath(s []string) Option {
 	})
 }
 
+// WithPathLevel use logging level for successful requests to a specific path
+func WithPathLevel(m map[string]zerolog.Level) Option {
+	return optionFunc(func(c *config) {
+		c.pathLevels = m
+	})
+}
+
 // WithWriter change the default output writer.
 // Default is gin.DefaultWriter
 func WithWriter(s io.Writer) Option {


### PR DESCRIPTION
Resolves #71 

The following can now be done:

```go
r := gin.New()
r.Use(logger.SetLogger(
    logger.WithPathLevel(map[string]zerolog.Level{"/health": zerolog.DebugLevel}),
)
```

Any successful requests to `/health` would result in a debug level log, instead of the default info level.