### PR TITLE
feat: add skipper functionality to logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ func main() {
     c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
   })
 
+  // Example of skipper usage
+  r.GET("/health", logger.SetLogger(
+    logger.WithSkipper(func(c *gin.Context) bool {
+      return c.Request.URL.Path == "/health"
+    }),
+  ), func(c *gin.Context) {
+    c.String(http.StatusOK, "pong "+fmt.Sprint(time.Now().Unix()))
+  })
+
   // Listen and Server in 0.0.0.0:8080
   if err := r.Run(":8080"); err != nil {
     log.Fatal().Msg("can' start server with 8080 port")

--- a/logger_test.go
+++ b/logger_test.go
@@ -226,6 +226,29 @@ func TestLoggerCustomLevel(t *testing.T) {
 	assert.Contains(t, buffer.String(), "FTL")
 }
 
+func TestLoggerSkipper(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.Use(SetLogger(
+		WithWriter(buffer),
+		WithSkipper(func(c *gin.Context) bool {
+			return c.Request.URL.Path == "/example2"
+		}),
+	))
+	r.GET("/example", func(c *gin.Context) {})
+	r.GET("/example2", func(c *gin.Context) {})
+
+	performRequest(r, "GET", "/example")
+	assert.Contains(t, buffer.String(), "GET")
+	assert.Contains(t, buffer.String(), "/example")
+
+	buffer.Reset()
+	performRequest(r, "GET", "/example2")
+	assert.NotContains(t, buffer.String(), "GET")
+	assert.NotContains(t, buffer.String(), "/example2")
+}
+
 func BenchmarkLogger(b *testing.B) {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()

--- a/options.go
+++ b/options.go
@@ -88,3 +88,12 @@ func WithServerErrorLevel(lvl zerolog.Level) Option {
 		c.serverErrorLevel = lvl
 	})
 }
+
+// WithSkipper set function to skip middleware
+// requests with this function returning true will not have their logs written
+// Default is nil
+func WithSkipper(s Skipper) Option {
+	return optionFunc(func(c *config) {
+		c.skip = s
+	})
+}


### PR DESCRIPTION
- Add skipper usage example in README.md
- Add `skip` field to logger config struct
- Modify `SetLogger` function to use the `skip` field
- Add `skipper` type and `WithSkipper` option function to logger.go
- Add tests for skipper functionality in logger_test.go
- Add `WithSkipper` option function to options.go