### PR TITLE
fix(leak): Avoid mutating logger

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -137,14 +137,16 @@ func SetLogger(opts ...Option) gin.HandlerFunc {
 			}
 		}
 
+		// Use a separate logger to save to the context, as we want to avoid mutating the original logger.
+		contextLogger := rl
 		if track {
-			l = l.With().
+			contextLogger = rl.With().
 				Str("method", c.Request.Method).
 				Str("path", path).
 				Str("ip", c.ClientIP()).
 				Str("user_agent", c.Request.UserAgent()).Logger()
 		}
-		c.Set(loggerKey, l)
+		c.Set(loggerKey, contextLogger)
 
 		c.Next()
 

--- a/logger_test.go
+++ b/logger_test.go
@@ -180,7 +180,7 @@ func TestCustomLoggerIssue68(t *testing.T) {
 	buffer := new(concurrentBuffer)
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
-	// Use JSON logger JSON will explicitly print keys multiple times if they are added multiple times (because of mutations to the logger)
+	// Use JSON logger as it will explicitly print keys multiple times if they are added multiple times (if there were mutations to the logger)
 	r.Use(SetLogger(
 		WithLogger(func(_ *gin.Context, l zerolog.Logger) zerolog.Logger { return l.Output(buffer).With().Logger() }),
 		WithDefaultLevel(zerolog.DebugLevel),

--- a/logger_test.go
+++ b/logger_test.go
@@ -180,7 +180,8 @@ func TestCustomLoggerIssue68(t *testing.T) {
 	buffer := new(concurrentBuffer)
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
-	// Use JSON logger as it will explicitly print keys multiple times if they are added multiple times (if there were mutations to the logger)
+	// Use JSON logger as it will explicitly print keys multiple times if they are added multiple times,
+	// which may happen if there are mutations to the logger.
 	r.Use(SetLogger(
 		WithLogger(func(_ *gin.Context, l zerolog.Logger) zerolog.Logger { return l.Output(buffer).With().Logger() }),
 		WithDefaultLevel(zerolog.DebugLevel),

--- a/logger_test.go
+++ b/logger_test.go
@@ -180,9 +180,9 @@ func TestCustomLoggerIssue68(t *testing.T) {
 	buffer := new(concurrentBuffer)
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()
-	l := zerolog.New(buffer)
+	// Use JSON logger JSON will explicitly print keys multiple times if they are added multiple times (because of mutations to the logger)
 	r.Use(SetLogger(
-		WithLogger(func(*gin.Context, zerolog.Logger) zerolog.Logger { return l }),
+		WithLogger(func(_ *gin.Context, l zerolog.Logger) zerolog.Logger { return l.Output(buffer).With().Logger() }),
 		WithDefaultLevel(zerolog.DebugLevel),
 		WithClientErrorLevel(zerolog.ErrorLevel),
 		WithServerErrorLevel(zerolog.FatalLevel),


### PR DESCRIPTION
Same as what happened in https://github.com/gin-contrib/logger/pull/69, the same bug was introduced later, in https://github.com/gin-contrib/logger/pull/76

The only reason this was not caught by the test `TestCustomLoggerIssue68` is because that feature is using `l` instead of `rl` so it's not even working correctly for custom loggers.

cc @appleboy 