### PR TITLE
refactor: the default writer is stderr for zerolog

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -84,7 +84,7 @@ func SetLogger(opts ...Option) gin.HandlerFunc {
 		defaultLevel:     zerolog.InfoLevel,
 		clientErrorLevel: zerolog.WarnLevel,
 		serverErrorLevel: zerolog.ErrorLevel,
-		output:           gin.DefaultWriter,
+		output:           os.Stderr,
 	}
 
 	// Apply each option to the config


### PR DESCRIPTION
- Change logger output from `gin.DefaultWriter` to `os.Stderr`

fix #100 