### PR TITLE
feat: add option to omit query string from path matching and logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,23 @@ func main() {
     })
   }
 
+  // Example of WithPathNoQuery usage
+  nq := r.Group("/no-query", logger.SetLogger(
+    logger.WithPathNoQuery(true),
+    logger.WithPathLevel(map[string]zerolog.Level{
+      // normally this wouldn't match /no-query/boring?foo, but WithPathNoQuery(true) makes it match
+      "/no-query/boring": zerolog.DebugLevel,
+    }),
+  ))
+  {
+    nq.GET("/boring", func(c *gin.Context) {
+      c.String(http.StatusOK, "OK")
+    })
+    nq.GET("/interesting", func(c *gin.Context) {
+      c.String(http.StatusOK, "OK")
+    })
+  }
+
   // Listen and Server in 0.0.0.0:8080
   if err := r.Run(":8080"); err != nil {
     log.Fatal().Msg("can' start server with 8080 port")

--- a/_example/main.go
+++ b/_example/main.go
@@ -143,6 +143,23 @@ func main() {
 		})
 	}
 
+	// Example of WithPathNoQuery usage
+	nq := r.Group("/no-query", logger.SetLogger(
+		logger.WithPathNoQuery(true),
+		logger.WithPathLevel(map[string]zerolog.Level{
+			// normally this wouldn't match /no-query/boring?foo, but WithPathNoQuery(true) makes it match
+			"/no-query/boring": zerolog.DebugLevel,
+		}),
+	))
+	{
+		nq.GET("/boring", func(c *gin.Context) {
+			c.String(http.StatusOK, "OK")
+		})
+		nq.GET("/interesting", func(c *gin.Context) {
+			c.String(http.StatusOK, "OK")
+		})
+	}
+
 	// Listen and Server in 0.0.0.0:8080
 	if err := r.Run(":8080"); err != nil {
 		log.Fatal().Msg("can' start server with 8080 port")

--- a/logger_test.go
+++ b/logger_test.go
@@ -310,6 +310,43 @@ func TestLoggerSkipper(t *testing.T) {
 	assert.NotContains(t, buffer.String(), "/example2")
 }
 
+func TestLoggerPathNoQuery(t *testing.T) {
+	buffer := new(bytes.Buffer)
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.Use(SetLogger(
+		WithWriter(buffer),
+		WithPathNoQuery(true),
+		WithPathLevel(map[string]zerolog.Level{
+			"/example2": zerolog.WarnLevel,
+		}),
+	))
+	r.GET("/example", func(c *gin.Context) {
+		l := Get(c)
+		l.Debug().Msg("contextlogger")
+	})
+	r.GET("/example2", func(c *gin.Context) {})
+
+	performRequest(r, "GET", "/example?foo=bar")
+	lines := strings.Split(strings.TrimSpace(buffer.String()), "\n")
+	assert.Len(t, lines, 2)
+	for i, line := range lines {
+		assert.Contains(t, line, " query=foo=bar ", "line %d", i)
+	}
+
+	// with no query string, the field should be omitted
+	buffer.Reset()
+	performRequest(r, "GET", "/example")
+	assert.NotContains(t, buffer.String(), "query=")
+
+	buffer.Reset()
+	performRequest(r, "GET", "/example2?foo=bar")
+	// this one should be logged at warn level because the query-free path matches
+	// the level map entry
+	assert.Contains(t, buffer.String(), "WRN")
+	assert.Contains(t, buffer.String(), " query=foo=bar ")
+}
+
 func BenchmarkLogger(b *testing.B) {
 	gin.SetMode(gin.ReleaseMode)
 	r := gin.New()

--- a/options.go
+++ b/options.go
@@ -157,3 +157,9 @@ func WithContext(fn func(*gin.Context, *zerolog.Event) *zerolog.Event) Option {
 		c.context = fn
 	})
 }
+
+func WithPathNoQuery(b bool) Option {
+	return optionFunc(func(c *config) {
+		c.pathNoQuery = b
+	})
+}


### PR DESCRIPTION
Adds an option (default disabled for backwards compatibility) to change the handling of the `path` field to omit the query string.

When enabled:
- The `path` is logged without the query string
- The query string, if non-empty, is logged in a new `query` field
- The `path` without the query string is used for matching in the the `WithSkipPath`, `WithSkipPathRegexps`, and `WithPathLevel` options

Why?
- With structured log aggregators, being able to aggregate on the base path without highly variable query strings can be helpful
- Overriding log levels by path is similarly likely to want to use the base path ignoring variable / user-submitted query strings