### PR TITLE
Do not append to configured log message

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -183,8 +183,9 @@ func SetLogger(opts ...Option) gin.HandlerFunc {
 			}
 			latency := end.Sub(start)
 
+			msg := cfg.message
 			if len(c.Errors) > 0 {
-				cfg.message += " with errors: " + c.Errors.String()
+				msg += " with errors: " + c.Errors.String()
 			}
 
 			evt := getLogEvent(rl, cfg, c, path)
@@ -201,7 +202,7 @@ func SetLogger(opts ...Option) gin.HandlerFunc {
 				Dur("latency", latency).
 				Str("user_agent", c.Request.UserAgent()).
 				Int("body_size", c.Writer.Size()).
-				Msg(cfg.message)
+				Msg(msg)
 		}
 	}
 }


### PR DESCRIPTION
There was a recent bug introduced recently (in https://github.com/gin-contrib/logger/pull/106) that caused the `with error:` section of the message to be appended every time after a request with an error happened. This is because it was appending to the configuration message and not to a copy of it.

This adds a test and fixes the issue by creating a copy before appending and using that to log.